### PR TITLE
Add CacheHelper to support automatic periodic cache cleanup

### DIFF
--- a/MLSwiftUtils.podspec
+++ b/MLSwiftUtils.podspec
@@ -1,14 +1,14 @@
 Pod::Spec.new do |s|
   s.name     = 'MLSwiftUtils'
-  s.version  = '5.0.0'
+  s.version  = '5.1.1'
   s.license  = 'MIT'
   s.summary  = 'MLSwiftUtils'
-  s.homepage = 'https://github.com/blkbrds/swiftutils-ios'
-  s.authors  = { 'Dai Ho' => 'daiho' }
-  s.source   = { :git => 'https://github.com/blkbrds/swiftutils-ios.git', :tag => s.version}
+  s.homepage = 'https://github.com/blkbrds/mlswiftutils-ios'
+  s.authors  = { 'Dai Ho V' => 'daiho' }
+  s.source   = { :git => 'https://github.com/blkbrds/mlswiftutils-ios.git', :tag => s.version}
   s.requires_arc = true
   s.ios.deployment_target = '14.0'
   s.swift_version = '5.0'
   s.ios.frameworks = 'Foundation', 'UIKit'
-  s.source_files = 'Sources/Classes/*.swift', 'Sources/Extensions/*.swift'
+  s.source_files = 'Sources/Helper/*.swift', 'Sources/Extensions/*.swift'
 end

--- a/MLSwiftUtils.xcodeproj/project.pbxproj
+++ b/MLSwiftUtils.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		12C986317B77D7ABFB3C3C6F /* Pods_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AD2BECCF992B0D91E960C280 /* Pods_Tests.framework */; };
+		206A64382FB46866009838C0 /* CacheHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 206A64372FB46860009838C0 /* CacheHelper.swift */; };
 		9B0B04A766D90744A21FACC4 /* Pods_MLSwiftUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7BD268572D0CD479E99DA436 /* Pods_MLSwiftUtils.framework */; };
 		B204CC319B099051C03BDD4C /* Pods_PodTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CC90DFF29AB37B6D0DEBE45A /* Pods_PodTest.framework */; };
 		C086AC182E01468700998DD2 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = C086AC172E01468200998DD2 /* Optional.swift */; };
@@ -69,6 +70,7 @@
 /* Begin PBXFileReference section */
 		024427016ED960227D9A8CC7 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		12CA0CA242CAE5AFAAF2F3DB /* Pods-MLSwiftUtils.releasetest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MLSwiftUtils.releasetest.xcconfig"; path = "Pods/Target Support Files/Pods-MLSwiftUtils/Pods-MLSwiftUtils.releasetest.xcconfig"; sourceTree = "<group>"; };
+		206A64372FB46860009838C0 /* CacheHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheHelper.swift; sourceTree = "<group>"; };
 		5A78C09A78B70F30AE14F808 /* Pods-PodTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PodTest.debug.xcconfig"; path = "Pods/Target Support Files/Pods-PodTest/Pods-PodTest.debug.xcconfig"; sourceTree = "<group>"; };
 		657BC397D02EF97097BADC6C /* Pods-MLSwiftUtils.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-MLSwiftUtils.debug.xcconfig"; path = "Pods/Target Support Files/Pods-MLSwiftUtils/Pods-MLSwiftUtils.debug.xcconfig"; sourceTree = "<group>"; };
 		71476F41AA0C7E0C7C36A603 /* Pods-SwiftUtils.releasetest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SwiftUtils.releasetest.xcconfig"; path = "Pods/Target Support Files/Pods-SwiftUtils/Pods-SwiftUtils.releasetest.xcconfig"; sourceTree = "<group>"; };
@@ -155,6 +157,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		206A64362FB46858009838C0 /* Helper */ = {
+			isa = PBXGroup;
+			children = (
+				206A64372FB46860009838C0 /* CacheHelper.swift */,
+			);
+			path = Helper;
+			sourceTree = "<group>";
+		};
 		95562877CEECB0905E1E2050 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -212,6 +222,7 @@
 		ECBAE7741DB773A600E520CE /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				206A64362FB46858009838C0 /* Helper */,
 				ECBAE77C1DB773A600E520CE /* Extensions */,
 				ECBAE7961DB773A600E520CE /* Info.plist */,
 			);
@@ -568,6 +579,7 @@
 				ECBAE7A91DB773A600E520CE /* NSLock.swift in Sources */,
 				ECBAE7A21DB773A600E520CE /* Float.swift in Sources */,
 				ECBAE7B31DB773A600E520CE /* UITableView.swift in Sources */,
+				206A64382FB46866009838C0 /* CacheHelper.swift in Sources */,
 				ECBAE7AF1DB773A600E520CE /* UIColor.swift in Sources */,
 				ECBAE7A71DB773A600E520CE /* NSDate.swift in Sources */,
 				ECBAE7B51DB773A600E520CE /* UIViewController.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ## Requirements
 
 - iOS 14.0+
-Version 5.0.0: - Xcode 16 ~ Swift 5.0+
+Version 5.1.1: - Xcode 16 ~ Swift 5.0+
 
 ## Installation
 
@@ -24,7 +24,7 @@ To integrate MLSwiftUtils into your Xcode project using CocoaPods, specify it in
 platform :ios, '14.0'
 use_frameworks!
 
-pod 'MLSwiftUtils', '5.0.0'
+pod 'MLSwiftUtils', '5.1.1'
 ```
 
 Then, run the following command:

--- a/Sources/Helper/CacheHelper.swift
+++ b/Sources/Helper/CacheHelper.swift
@@ -1,0 +1,105 @@
+//
+//  CacheHelper.swift
+//  MLSwiftUtils
+//
+//  Created by Huy Vo D. [2] VN.Danang on 13/5/26.
+//  Copyright © 2026 ML. All rights reserved.
+//
+
+import Foundation
+import WebKit
+
+public final class CacheHelper {
+
+    // MARK: - Singleton
+
+    public static let shared = CacheHelper()
+
+    // MARK: - Constants
+
+    private enum CacheType {
+        case directory
+        case website
+
+        var key: String {
+            switch self {
+            case .directory:
+                return "com.MLSwiftUtils.lastCacheDirectoryCleanupDate"
+            case .website:
+                return "com.MLSwiftUtils.lastWebsiteDataCleanupDate"
+            }
+        }
+    }
+
+    // MARK: - Properties
+
+    private let userDefaults = UserDefaults.standard
+
+    private init() {}
+
+    // MARK: - Public
+
+    /// Clears the app's `.cachesDirectory` if enough days have passed
+    /// since the last cleanup.
+    ///
+    /// Recommended to call in:
+    /// `application(_:didFinishLaunchingWithOptions:)`
+    ///
+    /// - Parameter minimumDaysBetweenClears:
+    ///   Minimum number of days between cleanups. Default: 7 days
+    public func clearCachesDirectoryIfNeeded(minimumDaysBetweenClears: Int = 7) {
+        let cacheType: CacheType = .directory
+        guard shouldClearCache(for: cacheType, minimumDaysBetweenClears: minimumDaysBetweenClears) else {
+            return
+        }
+        saveLastCleanupDate(for: cacheType)
+        DispatchQueue.global(qos: .background).async {
+            let fileManager = FileManager.default
+            guard let cachesURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else {
+                return
+            }
+            do {
+                let contentURLs = try fileManager.contentsOfDirectory(at: cachesURL, includingPropertiesForKeys: nil)
+                for url in contentURLs {
+                    try fileManager.removeItem(at: url)
+                }
+            } catch {
+                debugPrint(
+                    "CacheHelper - Error clearing caches directory: \(error)"
+                )
+            }
+        }
+    }
+
+    /// Clears all `WKWebView` website data if enough days have passed
+    /// since the last cleanup.
+    ///
+    /// Recommended to call in:
+    /// `application(_:willFinishLaunchingWithOptions:)`
+    ///
+    /// - Parameter minimumDaysBetweenClears:
+    ///   Minimum number of days between cleanups. Default: 7 days
+    public func clearWebsiteDataIfNeeded(minimumDaysBetweenClears: Int = 7) {
+        let cacheType: CacheType = .website
+        guard shouldClearCache(for: cacheType, minimumDaysBetweenClears: minimumDaysBetweenClears) else {
+            return
+        }
+        saveLastCleanupDate(for: cacheType)
+        WKWebsiteDataStore.default().removeData(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes(), modifiedSince: .distantPast) {}
+    }
+
+    // MARK: - Private
+    private func shouldClearCache(for cacheType: CacheType, minimumDaysBetweenClears: Int) -> Bool {
+        guard let lastClearedDate = userDefaults.object(forKey: cacheType.key) as? Date else {
+            // First launch -> save date and skip cleanup
+            saveLastCleanupDate(for: cacheType)
+            return false
+        }
+        let daysSinceLastClear = Calendar.current.dateComponents([.day], from: lastClearedDate, to: Date()).day ?? 0
+        return daysSinceLastClear >= minimumDaysBetweenClears
+    }
+
+    private func saveLastCleanupDate(for cacheType: CacheType) {
+        userDefaults.set(Date(), forKey: cacheType.key)
+    }
+}


### PR DESCRIPTION
### Cache Cleanup Optimization

- Added automatic cache cleanup mechanism to reduce app storage usage over time.
- The app now periodically clears temporary cache files and WebView website data.
- Cleanup is performed safely in the background and only after a configurable number of days.
- Improved storage management and long-term app performance.

### How to Use

Call the cache cleanup methods during app launch:

```swift
func application(
    _ application: UIApplication,
    willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
) -> Bool {

    CacheHelper.shared.clearWebsiteDataIfNeeded()

    return true
}

func application(
    _ application: UIApplication,
    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
) -> Bool {

    CacheHelper.shared.clearCachesDirectoryIfNeeded()

    return true
}
```

Optional:

```swift
CacheHelper.shared.clearCachesDirectoryIfNeeded(
    minimumDaysBetweenClears: 14
)
```

The helper automatically:
- Stores the last cleanup date
- Skips cleanup on first launch
- Clears cache only after the configured number of days